### PR TITLE
Fix template formatting in main.css

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -890,35 +890,13 @@ ul.footer-menu>li {
     }
 }
 
-    {
-        {
-        range site.Params.customCSS
-    }
-}
+{{ range site.Params.customCSS }}
+    {{ $custom := resources.Get . }}
 
-    {
-        {
-        $custom : =resources.Get .
-    }
-}
+    {{ $custom.Content }}
+{{ end }}
 
-    {
-        {
-        $custom.Content
-    }
-}
-
-    {
-        {
-        end
-    }
-}
-
-    {
-        {
-        if site.Params.isso.enabled
-    }
-}
+{{ if site.Params.isso.enabled }}
 
 #isso-thread .textarea {
     color: #000;
@@ -929,8 +907,4 @@ ul.footer-menu>li {
     z-index: 1;
 }
 
-    {
-        {
-        end
-    }
-}
+{{ end }}


### PR DESCRIPTION
Custom CSS wasn't working because the template formatting was incorrect, likely due to whatever CSS formatter you're using.