### PR TITLE
Corrects logic for enabling ToC

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,8 +1,12 @@
 {{ $toc := true }}
-{{ if isset .Site.Params "toc" }}
-  {{ $toc = .Site.Params.toc }}
+{{ if isset .Params "toc" }}
+  {{ $toc = .Params.toc }}
+{{ else }}
+  {{ $toc = ge .WordCount .Site.Params.tocWordCount }}
+  {{ if and (isset .Site.Params "toc") (not (.Site.Params.toc)) }}
+    {{ $toc = false }}
+  {{ end }}
 {{ end }}
-{{ $toc = and ($toc) (ge .WordCount .Site.Params.tocWordCount) }}
 
 
 {{ if $toc }}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,9 +1,8 @@
-{{ $toc := and ($.Site.Params.toc) (ge .WordCount $.Site.Params.tocWordCount) }}
-{{ if isset .Params "toc" }}
-  {{ $toc = .Params.toc }}
-{{ else }}
-  {{ $toc = true }}
+{{ $toc := true }}
+{{ if isset .Site.Params "toc" }}
+  {{ $toc = .Site.Params.toc }}
 {{ end }}
+{{ $toc = and ($toc) (ge .WordCount .Site.Params.tocWordCount) }}
 
 
 {{ if $toc }}


### PR DESCRIPTION
In the existing version, the ToC partial checks if `.Params "toc"` is set, which will never be set as the value must be accessed as .Site.Params, therefore the default value of true was always used.

This change rearranges the logic so that we correctly check if toc is set, and respect tocWordCount if that is set.