### PR TITLE
Corrects readNextPosts logic

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -23,8 +23,8 @@
     </article>
 
     {{ $readNextPosts := 3}}
-    {{ if isset .Site.Params "readNextPosts" }}
-        {{ $readNextPosts := .Site.Params.readNextPosts }}
+    {{ if isset .Site.Params "readnextposts" }}
+        {{ $readNextPosts = .Site.Params.readNextPosts }}
     {{ end }}
 
     {{ if gt $readNextPosts 0 }}


### PR DESCRIPTION
The docs at https://gohugo.io/functions/collections/isset/ specify that the isset function must be called with a lowercase representation of the key we wish to check.

If we do not, the function always returns false.