### PR TITLE
fix: tag name

### DIFF
--- a/layouts/partials/post-info.html
+++ b/layouts/partials/post-info.html
@@ -26,16 +26,16 @@
         {{ if .Params.categories }}
             <ul class="post-categories">
                 {{ range $cat_name := .Params.categories }}
-                    {{ $cat := ($.Site.GetPage (printf "/categories/%s" $cat_name | urlize )) }}
-                    <li><a href="{{ $cat.RelPermalink }}">{{ $cat.Title | default $cat_name }}</a></li>
+                    {{ $cat_url := (printf "/categories/%s" $cat_name | urlize ) }}
+                    <li><a href="{{ $cat_url }}">{{ $cat_name }}</a></li>
                 {{ end }}
             </ul>
         {{ end }}
         {{ if .Params.tags }}
             <ul class="post-tags">
                 {{ range $tag_name := .Params.tags }}
-                    {{ $tag := ($.Site.GetPage (printf "/tags/%s" $tag_name | urlize )) }}
-                    <li><a href="{{ $tag.RelPermalink }}">#{{ $tag.Title | default $tag_name }}</a></li>
+                    {{ $tag_url := (printf "/tags/%s" ($tag_name | urlize)) }}
+                    <li><a href="{{ $tag_url }}">#{{ $tag_name }}</a></li>
                 {{ end }}
             </ul>
         {{ end }}


### PR DESCRIPTION
This pull request includes changes to the `layouts/partials/post-info.html` file to simplify the code for generating category and tag URLs. The most important changes are:

Code simplification:

* Replaced the usage of `$.Site.GetPage` with direct URL generation for categories. (`[layouts/partials/post-info.htmlL29-R38](diffhunk://#diff-dec3600393231caed15ecc1579c0caff9882fc4b773b4f5b480645bea37764a2L29-R38)`)
* Replaced the usage of `$.Site.GetPage` with direct URL generation for tags. (`[layouts/partials/post-info.htmlL29-R38](diffhunk://#diff-dec3600393231caed15ecc1579c0caff9882fc4b773b4f5b480645bea37764a2L29-R38)`)