### PR TITLE
fix: use standard naming convention favicon partial

### DIFF
--- a/layouts/partials/head/favicons.html
+++ b/layouts/partials/head/favicons.html
@@ -1,2 +1,2 @@
 <link rel="icon" type="image/x-icon" href="{{ "favicon.ico" | absURL }}">
-<link rel="apple-touch-icon-precomposed" href="{{ "favicon.png" | absURL }}">
+<link rel="apple-touch-icon-precomposed" href="{{ "apple-touch-icon.png" | absURL }}">


### PR DESCRIPTION
`favicon.ico` is the classic favicon file supported by almost all browsers.

Apple touch icon is a special icon for iOS home screen bookmarks and generally different from the generic favicon. `apple-touch-icon.png` is the standard name Apple expects and is widely used. It is automatically generated when using tools like https://favicon.io/.

